### PR TITLE
Emit metrics from repo to spring actuator metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     compile('org.springframework.boot:spring-boot-starter-thymeleaf')
     compile('org.springframework.boot:spring-boot-starter-web')
-    compile('org.springframework.boot:spring-boot-actuator')
+    compile('org.springframework.boot:spring-boot-starter-actuator')
     compile("org.springframework.boot:spring-boot-starter-security")
 
     compile("org.cloudfoundry:cloudfoundry-client-reactor:$cfClientVersion")

--- a/src/main/kotlin/org/cloudfoundry/loggregator/logmon/statistics/LogTestExecutionsRepo.kt
+++ b/src/main/kotlin/org/cloudfoundry/loggregator/logmon/statistics/LogTestExecutionsRepo.kt
@@ -1,10 +1,15 @@
 package org.cloudfoundry.loggregator.logmon.statistics
 
 import org.springframework.stereotype.Repository
+import org.springframework.boot.actuate.metrics.GaugeService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Repository
 open class LogTestExecutionsRepo {
     private var allResults: MutableList<LogTestExecutionResults> = mutableListOf()
+
+    @Autowired
+    private lateinit var gaugeService:GaugeService
 
     open fun findAll(): List<LogTestExecutionResults> {
         return allResults
@@ -12,7 +17,9 @@ open class LogTestExecutionsRepo {
 
     open fun save(results: LogTestExecutionResults) {
         synchronized(this) {
-            allResults.add(results)
+           gaugeService.submit("logmon.logs_produced", results.logsProduced.toDouble());
+           gaugeService.submit("logmon.logs_consumed", results.logsConsumed.toDouble());
+           allResults.add(results)
         }
     }
 


### PR DESCRIPTION
The logs produced and logs consumed metrics collected into the repo are accessible in the UI but are also valuable as raw metrics emitted to a metric consumer.  Boot Actuator metrics service allows the metrics to be emitted in any way the boot metrics can be emiited (http endpoints, metrics exporters, etc.).  